### PR TITLE
[Backend] Clone a temp ADJ to check internet connection

### DIFF
--- a/backend/internal/adj/git.go
+++ b/backend/internal/adj/git.go
@@ -39,7 +39,7 @@ func updateRepo(AdjBranch string) error {
 		}
 
 		// If the clone is succesful, delete the temp files
-		if err = os.RemoveAll(RepoPath); err != nil {
+		if err = os.RemoveAll(tempPath); err != nil {
 			return err
 		}
 

--- a/backend/internal/adj/git.go
+++ b/backend/internal/adj/git.go
@@ -2,6 +2,7 @@ package adj
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -21,6 +22,27 @@ func updateRepo(AdjBranch string) error {
 			SingleBranch:  true,
 			Depth:         1,
 		}
+
+		// Try to clone the ADJ to a temp directory to check for accessibility to the repo (also checks internet connection)
+		tempPath := filepath.Join(os.TempDir(), "temp_adj")
+
+		// Remove previous failed cloning attempts
+		if err = os.RemoveAll(tempPath); err != nil {
+			return err
+		}
+
+		// Try to import the ADJ to the temp directory
+		_, err = git.PlainClone(tempPath, false, cloneOptions)
+		if err != nil {
+			// If the clone fails, work with the local ADJ
+			return nil
+		}
+
+		// If the clone is succesful, delete the temp files
+		if err = os.RemoveAll(RepoPath); err != nil {
+			return err
+		}
+
 		if _, err = os.Stat(RepoPath); os.IsNotExist(err) {
 			_, err = git.PlainClone(RepoPath, false, cloneOptions)
 			if err != nil {

--- a/backend/pkg/adj/git.go
+++ b/backend/pkg/adj/git.go
@@ -39,7 +39,7 @@ func updateRepo(AdjBranch string) error {
 		}
 
 		// If the clone is succesful, delete the temp files
-		if err = os.RemoveAll(RepoPath); err != nil {
+		if err = os.RemoveAll(tempPath); err != nil {
 			return err
 		}
 

--- a/backend/pkg/adj/git.go
+++ b/backend/pkg/adj/git.go
@@ -2,6 +2,7 @@ package adj
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -21,6 +22,27 @@ func updateRepo(AdjBranch string) error {
 			SingleBranch:  true,
 			Depth:         1,
 		}
+
+		// Try to clone the ADJ to a temp directory to check for accessibility to the repo (also checks internet connection)
+		tempPath := filepath.Join(os.TempDir(), "temp_adj")
+
+		// Remove previous failed cloning attempts
+		if err = os.RemoveAll(tempPath); err != nil {
+			return err
+		}
+
+		// Try to import the ADJ to the temp directory
+		_, err = git.PlainClone(tempPath, false, cloneOptions)
+		if err != nil {
+			// If the clone fails, work with the local ADJ
+			return nil
+		}
+
+		// If the clone is succesful, delete the temp files
+		if err = os.RemoveAll(RepoPath); err != nil {
+			return err
+		}
+
 		if _, err = os.Stat(RepoPath); os.IsNotExist(err) {
 			_, err = git.PlainClone(RepoPath, false, cloneOptions)
 			if err != nil {


### PR DESCRIPTION
Cloning the ADJ to a temp file will check for accessibility to the repo as well as internet connection. If the repo is unreachable, the backend will work with the local ADJ.