### PR TITLE
[Backend] Avoid overflooding console with exponential backoff

### DIFF
--- a/backend/pkg/transport/network/tcp/client.go
+++ b/backend/pkg/transport/network/tcp/client.go
@@ -39,6 +39,7 @@ func (client *Client) Dial() (net.Conn, error) {
 	var err error
 	var conn net.Conn
 	client.logger.Info().Msg("dialing")
+	// The max connection retries will not work because the for loop never completes, it always returns and the function is called again by transport.
 	for client.config.MaxConnectionRetries <= 0 || client.currentRetries < client.config.MaxConnectionRetries {
 		client.currentRetries++
 		conn, err = client.config.DialContext(client.config.Context, "tcp", client.address)

--- a/backend/pkg/transport/network/tcp/client.go
+++ b/backend/pkg/transport/network/tcp/client.go
@@ -49,6 +49,7 @@ func (client *Client) Dial() (net.Conn, error) {
 
 		if err == nil {
 			client.logger.Info().Msg("connected")
+			client.currentRetries = 0
 			return conn, nil
 		}
 		if client.config.Context.Err() != nil {


### PR DESCRIPTION
Avoid overflowing the console when dialing fails by correctly implementing the exponential backoff function in the code.