### PR TITLE
[Backend] Propagate fault

### DIFF
--- a/backend/cmd/config.go
+++ b/backend/cmd/config.go
@@ -14,9 +14,14 @@ type Network struct {
 	Manual bool
 }
 
+type Transport struct {
+	PropagateFault bool
+}
+
 type Config struct {
-	Vehicle vehicle.Config
-	Server  server.Config
-	Adj     Adj
-	Network Network
+	Vehicle   vehicle.Config
+	Server    server.Config
+	Adj       Adj
+	Network   Network
+	Transport Transport
 }

--- a/backend/cmd/config.toml
+++ b/backend/cmd/config.toml
@@ -24,4 +24,4 @@ test = true
 [network]
 manual = false
 [transport]
-propagate_fault = false
+propagate_fault = true

--- a/backend/cmd/config.toml
+++ b/backend/cmd/config.toml
@@ -23,3 +23,5 @@ branch = "main" # Leave blank when using ADJ as a submodule (like this: "")
 test = true
 [network]
 manual = false
+[transport]
+propagate_fault = false

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -33,8 +33,8 @@ import (
 	vehicle_models "github.com/HyperloopUPV-H8/h9-backend/internal/vehicle/models"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/broker"
-	connection_topic "github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/connection"
 	blcu_topics "github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/blcu"
+	connection_topic "github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/connection"
 	data_topic "github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/data"
 	logger_topic "github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/logger"
 	message_topic "github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/message"
@@ -322,6 +322,7 @@ func main() {
 
 	// <--- transport --->
 	transp := transport.NewTransport(trace.Logger)
+	transp.SetpropagateFault(config.Transport.PropagateFault)
 
 	// <--- vehicle --->
 	ipToBoardId := make(map[string]abstraction.BoardId)

--- a/backend/pkg/transport/transport.go
+++ b/backend/pkg/transport/transport.go
@@ -330,6 +330,15 @@ func (transport *Transport) handleConversation(socket network.Socket, reader io.
 				return
 			}
 
+			// Intercept packets with id == 0 and replicate
+			if packet.Id() == 0 {
+				conversationLogger.Info().Msg("replicating packet with id 0 to all boards")
+				err := transport.handlePacketEvent(NewPacketMessage(packet))
+				if err != nil {
+					conversationLogger.Error().Err(err).Msg("failed to replicate packet")
+				}
+			}
+
 			transport.api.Notification(NewPacketNotification(packet, srcAddr, dstAddr, time.Now()))
 		}
 	}()

--- a/backend/pkg/transport/transport.go
+++ b/backend/pkg/transport/transport.go
@@ -36,6 +36,8 @@ type Transport struct {
 
 	tftp *tftp.Client
 
+	propagateFault bool
+
 	api abstraction.TransportAPI
 
 	logger zerolog.Logger
@@ -331,7 +333,7 @@ func (transport *Transport) handleConversation(socket network.Socket, reader io.
 			}
 
 			// Intercept packets with id == 0 and replicate
-			if packet.Id() == 0 {
+			if transport.propagateFault && packet.Id() == 0 {
 				conversationLogger.Info().Msg("replicating packet with id 0 to all boards")
 				err := transport.handlePacketEvent(NewPacketMessage(packet))
 				if err != nil {
@@ -361,4 +363,8 @@ func (transport *Transport) SendFault() {
 	// if err != nil {
 	// transport.errChan <- err
 	// }
+}
+
+func (transport *Transport) SetpropagateFault(enabled bool) {
+	transport.propagateFault = enabled
 }

--- a/backend/pkg/transport/transport.go
+++ b/backend/pkg/transport/transport.go
@@ -172,6 +172,14 @@ func (transport *Transport) handleTCPConn(conn net.Conn) error {
 				return
 			}
 
+			if transport.propagateFault && packet.Id() == 0 {
+				connectionLogger.Info().Msg("replicating packet with id 0 to all boards")
+				err := transport.handlePacketEvent(NewPacketMessage(packet))
+				if err != nil {
+					connectionLogger.Error().Err(err).Msg("failed to replicate packet")
+				}
+			}
+
 			from := conn.RemoteAddr().String()
 			to := conn.LocalAddr().String()
 


### PR DESCRIPTION
When the backend receives a packet with id = 0, it will send it to all other boards, only when enabled on the config.toml.