### PR TITLE
[Backend] Warn when using local ADJ

### DIFF
--- a/backend/internal/adj/git.go
+++ b/backend/internal/adj/git.go
@@ -1,6 +1,7 @@
 package adj
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 
@@ -35,6 +36,7 @@ func updateRepo(AdjBranch string) error {
 		_, err = git.PlainClone(tempPath, false, cloneOptions)
 		if err != nil {
 			// If the clone fails, work with the local ADJ
+			log.Printf("Warning: Could not clone ADJ branch '%s' from remote. Working with local ADJ. Error: %v", AdjBranch, err)
 			return nil
 		}
 

--- a/backend/pkg/adj/git.go
+++ b/backend/pkg/adj/git.go
@@ -1,6 +1,7 @@
 package adj
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 
@@ -35,6 +36,7 @@ func updateRepo(AdjBranch string) error {
 		_, err = git.PlainClone(tempPath, false, cloneOptions)
 		if err != nil {
 			// If the clone fails, work with the local ADJ
+			log.Printf("Warning: Could not clone ADJ branch '%s' from remote. Working with local ADJ. Error: %v", AdjBranch, err)
 			return nil
 		}
 


### PR DESCRIPTION
Small QOL change: Warn the user when the remote ADJ could not be cloned and the local ADJ is being used. Before this, there was no way of knowing if the remote ADJ cloning was successful or not.