### PR TITLE
[Backend] Show a confirmation message on the frontend when an order is sent

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -181,11 +181,8 @@ func main() {
 	connectionTopic := connection_topic.NewUpdateTopic()
 	orderTopic := order_topic.NewSendTopic()
 	loggerTopic := logger_topic.NewEnableTopic()
-	boardIdToBoard := make(map[abstraction.BoardId]string)
-	for name, id := range adj.Info.BoardIds {
-		boardIdToBoard[abstraction.BoardId(id)] = name
-	}
-	messageTopic := message_topic.NewUpdateTopic(boardIdToBoard)
+
+	messageTopic := message_topic.NewUpdateTopic()
 	stateOrderTopic := order_topic.NewState(idToBoard, trace.Logger)
 
 	broker.AddTopic(data_topic.UpdateName, dataTopic)

--- a/backend/pkg/broker/topics/message/message_test.go
+++ b/backend/pkg/broker/topics/message/message_test.go
@@ -34,7 +34,7 @@ func TestMessageTopic_Push(t *testing.T) {
 	client := websocket.NewClient(c)
 	clientChan <- client
 
-	messageTopic := data.NewUpdateTopic(map[abstraction.BoardId]string{})
+	messageTopic := data.NewUpdateTopic()
 	messageTopic.SetAPI(api)
 	messageTopic.SetPool(pool)
 
@@ -80,7 +80,7 @@ func TestMessageTopic_ClientMessage(t *testing.T) {
 	logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
 	api := broker.New(logger)
 
-	messageTopic := data.NewUpdateTopic(map[abstraction.BoardId]string{})
+	messageTopic := data.NewUpdateTopic()
 	messageTopic.SetAPI(api)
 
 	packet := protection.NewPacket(0, protection.OkSeverity)

--- a/backend/pkg/broker/topics/message/message_test.go
+++ b/backend/pkg/broker/topics/message/message_test.go
@@ -39,7 +39,7 @@ func TestMessageTopic_Push(t *testing.T) {
 	messageTopic.SetPool(pool)
 
 	// Simulate sending a download request
-	request := data.Push("test", 0)
+	request := data.Push("test", "test_board")
 	err = messageTopic.Push(request)
 	if err != nil {
 		t.Fatal("Error pushing download request:", err)
@@ -84,7 +84,7 @@ func TestMessageTopic_ClientMessage(t *testing.T) {
 	messageTopic.SetAPI(api)
 
 	packet := protection.NewPacket(0, protection.OkSeverity)
-	payload := data.Push(packet, 0)
+	payload := data.Push(packet, "test_board")
 	payloadBytes, _ := json.Marshal(payload)
 	messageTopic.ClientMessage(websocket.ClientId{0}, &websocket.Message{
 		Topic:   data.SubscribeName,

--- a/backend/pkg/broker/topics/message/update.go
+++ b/backend/pkg/broker/topics/message/update.go
@@ -7,11 +7,14 @@ import (
 
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/packet/data"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/packet/protection"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/websocket"
 	"github.com/google/uuid"
 	ws "github.com/gorilla/websocket"
 )
+
+var _ = data.Packet{}
 
 const UpdateName abstraction.BrokerTopic = "message/update"
 const SubscribeName abstraction.BrokerTopic = "message/update"
@@ -128,8 +131,17 @@ func (push *pushStruct) Data(boardID abstraction.BoardId, idToBoard map[abstract
 			Name:      string(data.Name),
 			Timestamp: data.Timestamp,
 		}
+	case *data.Packet:
+		return wrapper{
+			Kind:      "info",
+			Payload:   "Order Sent",
+			Board:     string(idToBoard[boardID]),
+			Name:      string(data.Id()),
+			Timestamp: protection.NowTimestamp(),
+		}
 	}
 	return wrapper{}
+
 }
 
 type wrapper struct {

--- a/backend/pkg/broker/topics/message/update.go
+++ b/backend/pkg/broker/topics/message/update.go
@@ -26,7 +26,7 @@ type Update struct {
 	api           abstraction.BrokerAPI
 }
 
-func NewUpdateTopic(idToBoard map[abstraction.BoardId]string) *Update {
+func NewUpdateTopic() *Update {
 	return &Update{
 		subscribersMx: &sync.Mutex{},
 		subscribers:   make(map[websocket.ClientId]struct{}),

--- a/backend/pkg/vehicle/notification.go
+++ b/backend/pkg/vehicle/notification.go
@@ -84,7 +84,7 @@ func (vehicle *Vehicle) handlePacketNotification(notification transport.PacketNo
 
 	case *protection.Packet:
 		boardId := vehicle.ipToBoardId[strings.Split(notification.From, ":")[0]]
-		err := vehicle.broker.Push(message_topic.Push(p, boardId))
+		err := vehicle.broker.Push(message_topic.Push(p, vehicle.idToBoardName[uint16(p.Id())]))
 		if err != nil {
 			vehicle.trace.Error().Stack().Err(err).Msg("broker push")
 			return errors.Join(fmt.Errorf("update protection to frontend (%s protection with id %d and kind %d from %s to %s)", p.Severity(), p.Id(), p.Kind, notification.From, notification.To), err)

--- a/backend/pkg/vehicle/vehicle.go
+++ b/backend/pkg/vehicle/vehicle.go
@@ -54,6 +54,12 @@ func (vehicle *Vehicle) UserPush(push abstraction.BrokerPush) error {
 			return err
 		}
 
+		err = vehicle.broker.Push(message_topic.Push(packet, 1)) // TODO: Get board ID, it's currently hardcoded
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error sending info packet to the frontend: %v\n", err)
+			return err
+		}
+
 		err = vehicle.transport.SendMessage(transport.NewPacketMessage(packet))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error sending packet: %v\n", err)
@@ -66,7 +72,6 @@ func (vehicle *Vehicle) UserPush(push abstraction.BrokerPush) error {
 			To:        vehicle.idToBoardName[uint16(packet.Id())],
 			Timestamp: packet.Timestamp(),
 		})
-
 		if err != nil && !errors.Is(err, logger.ErrLoggerNotRunning{}) {
 			fmt.Fprintln(os.Stderr, "Error pushing record to logger: ", err)
 		}

--- a/backend/pkg/vehicle/vehicle.go
+++ b/backend/pkg/vehicle/vehicle.go
@@ -54,15 +54,15 @@ func (vehicle *Vehicle) UserPush(push abstraction.BrokerPush) error {
 			return err
 		}
 
-		err = vehicle.broker.Push(message_topic.Push(packet, vehicle.idToBoardName[uint16(packet.Id())]))
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error sending info packet to the frontend: %v\n", err)
-			return err
-		}
-
 		err = vehicle.transport.SendMessage(transport.NewPacketMessage(packet))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error sending packet: %v\n", err)
+			return err
+		}
+
+		err = vehicle.broker.Push(message_topic.Push(packet, vehicle.idToBoardName[uint16(packet.Id())]))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error sending info packet to the frontend: %v\n", err)
 			return err
 		}
 

--- a/backend/pkg/vehicle/vehicle.go
+++ b/backend/pkg/vehicle/vehicle.go
@@ -54,7 +54,7 @@ func (vehicle *Vehicle) UserPush(push abstraction.BrokerPush) error {
 			return err
 		}
 
-		err = vehicle.broker.Push(message_topic.Push(packet, 1)) // TODO: Get board ID, it's currently hardcoded
+		err = vehicle.broker.Push(message_topic.Push(packet, vehicle.idToBoardName[uint16(packet.Id())]))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error sending info packet to the frontend: %v\n", err)
 			return err
@@ -183,5 +183,5 @@ func (vehicle *Vehicle) notifyError(name string, err error) {
 	packet.Data = &protection.ErrorHandler{
 		Error: err.Error(),
 	}
-	vehicle.broker.Push(message_topic.Push(packet, 255))
+	vehicle.broker.Push(message_topic.Push(packet, "Error"))
 }


### PR DESCRIPTION
When an order is sent from the PC to a board, the backend will send a confirmation message that will show on the frontend.
Changes to broker logic:
The function Push used to send these types of messages from the backend to the frontend now uses the board's name as a string instead of the board's ID and the idToBoardName map. This means that the process calling this function is in charge of getting the name. As a result, the boardIdToBoard map has been removed, as it isn't necessary any more.